### PR TITLE
mob追従処理仮完成、Wiiリモコン振動調整

### DIFF
--- a/Misoten8/Assets/Scripts/Display/Title/ShakeIcon.cs
+++ b/Misoten8/Assets/Scripts/Display/Title/ShakeIcon.cs
@@ -6,8 +6,7 @@ using UnityEngine.UI;
 /// </summary>
 public class ShakeIcon : UIBase 
 {
-	[SerializeField]
-	private int _borderShakeCount;
+	private int _borderShakeCount = Define.SCENE_TRANCE_VALUE;
 	private Image _image;
 	private float _drawValue = 0.0f;
 

--- a/Misoten8/Assets/Scripts/Input/Wiimote/Wiimote.cs
+++ b/Misoten8/Assets/Scripts/Input/Wiimote/Wiimote.cs
@@ -243,6 +243,17 @@ public class Wiimote
         }
     }
 
+        public void Uninit()
+        {
+            _Accel = null;
+            _Button = null;
+            _Accel = null;
+            _Button = null;
+            _Ir = null;
+            _Status = null;
+            _Extension = null;
+        }
+
     #region Setups
 
     /// \brief Performs a series of coperations to initialize the IR camera.
@@ -905,5 +916,11 @@ public class Wiimote
             RequestIdentifyWiiMotionPlus();
             ActivateWiiMotionPlus();
        }
+
+        // LEDê›íËä÷êî
+        public void SetLED(int ledNum)
+        {
+            SendPlayerLED(ledNum == 1, ledNum == 2, ledNum == 3, ledNum == 4);
+        }
     }
 }

--- a/Misoten8/Assets/Scripts/Input/Wiimote/WiimoteData/MotionPlusData.cs
+++ b/Misoten8/Assets/Scripts/Input/Wiimote/WiimoteData/MotionPlusData.cs
@@ -132,8 +132,6 @@ namespace WiimoteApi {
             _RollSpeed = 0;
         }
 
-        float accelOld = 0.0f;
-        bool swinged = false;
 		public bool GetSwing( int num)
 		{
 			if (!WiimoteManager.HasWiimote(num) )return false;
@@ -141,14 +139,9 @@ namespace WiimoteApi {
 			float ac = 0.0f;
 
 			ac = PitchSpeed + RollSpeed + YawSpeed;
-            if (ac > 300.0f && accelOld < ac && swinged == false)
-            {
+            if( ac > 300.0f)
+            { 
                 swing = true;
-                swinged = true;
-            }
-            else if( ac < 50.0f)
-            {
-                swinged = false;
             }
             return swing;
 		}

--- a/Misoten8/Assets/Scripts/Input/Wiimote/WiimoteManager.cs
+++ b/Misoten8/Assets/Scripts/Input/Wiimote/WiimoteManager.cs
@@ -48,8 +48,6 @@ namespace WiimoteApi
                 Wiimote wm = Wiimotes[wiiNumber];
                 wm.InitWiiMotionPlus();
                 wm.Speaker.Init();
-                int i = wiiNumber + 1;
-                wm.SendPlayerLED(i == 1, i == 2, i == 3, i == 4);
                 Rumble(wiiNumber, false);
             }
         }
@@ -146,6 +144,7 @@ namespace WiimoteApi
         {
             if (remote != null)
             {
+                remote.Uninit();
                 if (remote.hidapi_handle != IntPtr.Zero)
                 {
                     HIDapi.hid_close(remote.hidapi_handle);

--- a/Misoten8/Assets/Scripts/Move/FollowMove.cs
+++ b/Misoten8/Assets/Scripts/Move/FollowMove.cs
@@ -9,36 +9,36 @@ using UnityEngine.AI;
 /// </summary>
 public class FollowMove : MonoBehaviour, IMove
 {
-	/// <summary>
-	/// 遷移条件判定イベント
-	/// FixedUpdateのタイミングで呼ばれます
-	/// </summary>
-	public Action OnTransCheck
-	{
-		set { _onTransCheck += value; }
-	}
+    /// <summary>
+    /// 遷移条件判定イベント
+    /// FixedUpdateのタイミングで呼ばれます
+    /// </summary>
+    public Action OnTransCheck
+    {
+        set { _onTransCheck += value; }
+    }
 
-	private Action _onTransCheck;
+    private Action _onTransCheck;
 
-	/// <summary>
-	/// 移動する速度
-	/// </summary>
-	[SerializeField]
-	private float _velocity;
+    /// <summary>
+    /// 移動する速度
+    /// </summary>
+    [SerializeField]
+    private float _velocity;
 
-	/// <summary>
-	/// 移動を中止する距離
-	/// </summary>
-	[SerializeField]
-	private float _stopDistance;
+    /// <summary>
+    /// 移動を中止する距離
+    /// </summary>
+    [SerializeField]
+    private float _stopDistance;
 
-	/// <summary>
-	/// 速度の減少を開始する距離
-	/// </summary>
-	[SerializeField]
-	private float _slowDistance;
+    /// <summary>
+    /// 速度の減少を開始する距離
+    /// </summary>
+    [SerializeField]
+    private float _slowDistance;
 
-	private Transform _target = null;
+    private Transform _target = null;
 
     private NavMeshAgent _agent = null;
 
@@ -54,68 +54,55 @@ public class FollowMove : MonoBehaviour, IMove
 	/// 初期化処理
 	/// </summary>
 	public void OnStart(Transform target)
-	{
-		_target = target;
+    {
+        _target = target;
         _player = _target.GetComponent<Player>();
-		enabled = true;
+        enabled = true;
         _agent = GetComponent<NavMeshAgent>();
         _agent.enabled = true;
         _mob = GetComponent<Mob>();
         mobInterval = 2.0f;
-	}
+    }
 
-	void OnDisable()
-	{
-		_target = null;
+    void OnDisable()
+    {
+        _target = null;
         _agent = null;
-	}
+    }
 
-	void Update()
-	{
-		if (_target == null)
-		{
-			Debug.Log("追従対象が見つからない為、非アクティブになります");
-			enabled = false;
-			return;
-		}
-
-        // 目標座標設定
-        Vector3 goal = _target.position;
-        float angle = Mathf.PI * 0.75f;
-        float angle2 = angle * 2;
-        bool debugMode = true;
-        float rot = SetDirection(_target.position, _player.TargetObj.position);
-
-        if (_mob.IsViewingInDance || debugMode)
+    void Update()
+    {
+        if (_target == null)
         {
-            // プレイヤーダンス中追従
-            goal.x += Mathf.Sin(rot + angle - ((fanNum % 2) * angle2)) * (-mobInterval * (fanNum % cutNum + 1)) +
-                        Mathf.Sin(rot) * ((mobInterval) * (fanNum / cutNum));
+            Debug.Log("追従対象が見つからない為、非アクティブになります");
+            enabled = false;
+            return;
+        }
+        Vector3 goal = _player.TargetObj.position;
+        goal.z = -goal.z;
+        _agent.SetDestination(_player.TargetObj.position);
 
-            goal.z += Mathf.Cos(rot + angle - ((fanNum % 2) * angle2)) * (-mobInterval * (fanNum % cutNum + 1)) +
-                        Mathf.Cos(rot) * ((mobInterval) * (fanNum / cutNum));
-
-            _agent.SetDestination(goal);
+        if (_agent.remainingDistance < 1.0f + (_mob._followInex * mobInterval))
+        {
+            _agent.isStopped = true;
         }
         else
         {
-            // プレイヤー移動中追従
-            goal.x += -Mathf.Sin((rot) * (Mathf.PI * 0.5f)) * 4.0f + (-Mathf.Sin(rot) * ((mobInterval) * (fanNum / cutNum)));
-            goal.z += -Mathf.Cos((rot) * (Mathf.PI * 0.5f)) * 4.0f + (-Mathf.Cos(rot) * ((mobInterval) * (fanNum / cutNum)));
-            _agent.SetDestination(goal);
+            _agent.isStopped = false;
         }
-
-            // 遷移チェック
-            _onTransCheck?.Invoke();
-	}
+        // 遷移チェック
+        _onTransCheck?.Invoke();
+    }
 
     // 
     float SetDirection(Vector3 p1, Vector3 p2)
     {
+        Debug.Log("Target: " + p2);
         float dx, dy;
         dx = p1.x - p2.x;
-        dy = p1.y - p2.y;
+        dy = p1.z - p2.z;
         float rad = Mathf.Atan2(dy, dx);
+        Debug.Log("rot : " + rad);
         return rad * Mathf.Rad2Deg;
     }
 }

--- a/Misoten8/Assets/Scripts/Player/Player.cs
+++ b/Misoten8/Assets/Scripts/Player/Player.cs
@@ -106,14 +106,14 @@ public class Player : Photon.PunBehaviour
 		_playerManager = caches.playerManager;
 		_mobManager = caches.mobManager;
 		_playercamera = caches.playercamera;
-
+        _targetObj.localPosition = new Vector3( _targetObj.localPosition.x, _targetObj.localPosition.y,-_targetObj.localPosition.z);
 		// プレイヤーを管理クラスに登録
 		_playerManager.SetPlayer(this);
 
 		_type = (Define.PlayerType)(int)photonView.instantiationData[0];
+        WiimoteManager.Wiimotes[0].SetLED((int)_type);
 		_playerColor = Define.playerColor[(int)_type];
 		_dance.OnAwake(_playercamera);
-
 		Debug.Log("生成受信データ player ID : " + ((int)photonView.instantiationData[0]).ToString() + "\n クライアントID : " + PhotonNetwork.player.ID.ToString());
 		
 		// モデルの設定
@@ -160,7 +160,7 @@ public class Player : Photon.PunBehaviour
 				transform.Rotate(Vector3.up, _rotatePower);
 			if (Input.GetKey("down") || WiimoteManager.GetButton(0, ButtonData.WMBUTTON_LEFT))
 				_rb.AddForce(-transform.forward * _power);
-			if (shakeparameter.IsOverWithValue(3))
+			if (shakeparameter.IsOverWithValue(2))
 			{
                 _playercamera.SetDollyPosition(transform);//ドリーの位置設定
                 photonView.RPC("DanceBegin", PhotonTargets.AllViaServer, (byte)_type);

--- a/Misoten8/Assets/Scripts/Scene/Lobby/LobbyScene.cs
+++ b/Misoten8/Assets/Scripts/Scene/Lobby/LobbyScene.cs
@@ -30,7 +30,7 @@ public class LobbyScene : SceneBase<LobbyScene>
 
 	void Update () 
 	{
-		if (shakeparameter.IsOverWithValue(2))
+		if (shakeparameter.IsOverWithValue(Define.SCENE_TRANCE_VALUE))
 		{
 			if (PhotonNetwork.inRoom)
 			{

--- a/Misoten8/Assets/Scripts/Scene/Result/ResultScene.cs
+++ b/Misoten8/Assets/Scripts/Scene/Result/ResultScene.cs
@@ -28,7 +28,7 @@ public class ResultScene : SceneBase<ResultScene>
 
 	void Update ()
 	{
-		if (shakeparameter.IsOverWithValue(2))
+		if (shakeparameter.IsOverWithValue(Define.SCENE_TRANCE_VALUE))
 		{
 			Switch(SceneType.Title);
 		}

--- a/Misoten8/Assets/Scripts/Scene/SceneBase.cs
+++ b/Misoten8/Assets/Scripts/Scene/SceneBase.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using System.Collections;
+using WiimoteApi;
 
 /// <summary>
 /// シーン基底クラス
@@ -117,6 +118,12 @@ public abstract class SceneBase<T> : MonoBehaviour where T : SceneBase<T>
 		if (PhotonNetwork.room == null)
 			return;
 
+        // Wiiリモコン終了処理
+        if (WiimoteManager.Wiimotes[0] != null)
+        {
+            WiimoteManager.Cleanup(WiimoteManager.Wiimotes[0]);
+            WiimoteManager.Wiimotes[0] = null;
+        }
 		// ルーム退室  
 		PhotonNetwork.LeaveRoom();
 		// ネットワーク切断

--- a/Misoten8/Assets/Scripts/Scene/Title/TitleScene.cs
+++ b/Misoten8/Assets/Scripts/Scene/Title/TitleScene.cs
@@ -28,7 +28,7 @@ public class TitleScene : SceneBase<TitleScene>
 
 	void Update()
 	{
-		if (shakeparameter.IsOverWithValue(2))
+		if (shakeparameter.IsOverWithValue(Define.SCENE_TRANCE_VALUE))
 		{
 			Switch(SceneType.Lobby);
 		}

--- a/Misoten8/Assets/Scripts/Utility/Define.cs
+++ b/Misoten8/Assets/Scripts/Utility/Define.cs
@@ -26,6 +26,9 @@ public static class Define
 
 	public const int FAN_SCORE_HARD = 100;
 
+
+
+    public const int SCENE_TRANCE_VALUE = 16;
 	/// <summary>
 	/// ファンポイント最大値(この値によって各プレイヤーに割り振られるスコアポイントが決まる)
 	/// </summary>


### PR DESCRIPTION
mobの追従処理を常にプレイヤーの後ろ側についてくるように仮完成。
Wiiリモコンの振動判定の調整。
->Wiiリモコンの振動に関わっている処理を一部調整しました。

Playerの初期化にプレイヤー番号のLEDを点灯させる処理を追加.
