### PR TITLE
待機カメラの初期位置を調整

### DIFF
--- a/Misoten8/Assets/ImportAssets/Scripts_Ando/Towncameramove.cs
+++ b/Misoten8/Assets/ImportAssets/Scripts_Ando/Towncameramove.cs
@@ -14,8 +14,13 @@ public class Towncameramove : MonoBehaviour
     private float dollytime = 0.0f;
     private void Awake()
     {
-        currentDistance = 0.0f;
+        dolly = virtualCamera.GetCinemachineComponent<CinemachineTrackedDolly>();
+        if (path != null)
+            SamplePath(path.m_Appearance.steps); // TODO: decouple numSteps from appearance setting
+
         dollytime = 0.0f;
+        currentDistance = dollytime;
+        currentDistance = currentDistance % pathLength;
         dolly.m_PathPosition = curve.Evaluate(currentDistance);
     }
     void SamplePath(int stepsPerSegment)
@@ -36,12 +41,7 @@ public class Towncameramove : MonoBehaviour
             p0 = p;
         }
     }
-    void Start()
-    {
-        dolly = virtualCamera.GetCinemachineComponent<CinemachineTrackedDolly>();
-        if (path != null)
-            SamplePath(path.m_Appearance.steps); // TODO: decouple numSteps from appearance setting
-    }
+  
     void Update()
     {
         int numKeys = (curve != null && curve.keys != null) ? curve.keys.Length : 0;

--- a/Misoten8/Assets/ImportAssets/Scripts_Ando/Towncameramove.cs
+++ b/Misoten8/Assets/ImportAssets/Scripts_Ando/Towncameramove.cs
@@ -12,7 +12,12 @@ public class Towncameramove : MonoBehaviour
     private float pathLength;
     private CinemachineTrackedDolly dolly;
     private float dollytime = 0.0f;
-
+    private void Awake()
+    {
+        currentDistance = 0.0f;
+        dollytime = 0.0f;
+        dolly.m_PathPosition = curve.Evaluate(currentDistance);
+    }
     void SamplePath(int stepsPerSegment)
     {
         curve = new AnimationCurve();

--- a/Misoten8/Assets/ImportAssets/Scripts_Ando/playercamera.cs
+++ b/Misoten8/Assets/ImportAssets/Scripts_Ando/playercamera.cs
@@ -51,6 +51,10 @@ public class playercamera : MonoBehaviour {
     [SerializeField] private DanceCamera[] dancecamera = new DanceCamera[CAMERA_MAX];
     [SerializeField] private CinemachineVirtualCamera[] cinemachineVirtualCamera = new CinemachineVirtualCamera[CAMERA_MAX];
     [SerializeField] private dancecameradolly dancecameradolly;
+    private void Awake()
+    {
+       SetCameraPriority((int)CAMERATYPE.WAITING);
+    }
     //=======================================
     //関数名 Start
     //引き数
@@ -76,7 +80,6 @@ public class playercamera : MonoBehaviour {
             case CAMERAMODE.WAITING:
                 Setblend(1);
                 SetCameraPriority((int)CAMERATYPE.WAITING);
-                //SetCameraMode(CAMERAMODE.NORMAL);
                 break;
             //===========================
             //後ろから追従するカメラ

--- a/Misoten8/Assets/ImportAssets/Scripts_Ando/playercamera.cs
+++ b/Misoten8/Assets/ImportAssets/Scripts_Ando/playercamera.cs
@@ -87,6 +87,7 @@ public class playercamera : MonoBehaviour {
             case CAMERAMODE.NORMAL:
                 Setblend(1);
                 SetCameraPriority((int)CAMERATYPE.PLAYER);
+       
                 break;
             //===========================
             //プレイヤーを前から撮影


### PR DESCRIPTION
playercameraのawakeで
初期カメラ設定をwaitcameraにする事で虚空を見つめるバグを修正
towncameramoveのawakeで
初期ドリー位置を0.0fに初期化する事で初期ドリー位置が不定なバグを修正